### PR TITLE
Changebale game rate

### DIFF
--- a/rtp-admin
+++ b/rtp-admin
@@ -1,33 +1,59 @@
 #!/usr/bin/env python
 
 import sys
+import os
 import xmlrpclib
 from rtp.common import config
 
-VERBS = ('start', 'stop')
+class Client(object):
 
-def main():
-    if len(sys.argv) != 2:
-        usage('No verb specified')
+    def __init__(self, args):
+        self.args = args
+        url = 'http://127.0.0.1:%d/rpc2' % config.web_port
+        self.server = xmlrpclib.Server(url)
 
-    verb = sys.argv[1]
-    if verb not in VERBS:
-        usage('unknown verb: %r' % verb)
+    def run(self):
+        if len(sys.argv) < 2:
+            self.usage('No verb specified')
 
-    url = 'http://127.0.0.1:%d/rpc2' % config.web_port
-    server = xmlrpclib.Server(url)
-    method = getattr(server, verb)
-    try:
-        method()
-    except Exception as e:
-        print e
-        sys.exit(1)
+        verb = self.args[1]
+        method_name = 'do_' + verb.replace('-', '_')
+        try:
+            method = getattr(self, method_name)
+        except AttributeError:
+            self.usage('Unknown verb: %r' % verb)
+        try:
+            method()
+        except Exception as e:
+            print e
+            sys.exit(1)
 
-def usage(msg):
-    if msg:
-        print msg
-    print 'usage: %s [%s]' % (sys.argv[0], '|'.join(VERBS))
-    sys.exit(2)
+    def do_start(self):
+        """start"""
+        self.server.start()
+
+    def do_stop(self):
+        """stop"""
+        self.server.stop()
+
+    def do_set_rate(self):
+        """set-rate RATE"""
+        if len(self.args) < 3:
+            self.usage("RATE required")
+        rate = float(self.args[2])
+        self.server.set_rate(rate)
+
+    def commands(self):
+        return sorted(getattr(self, name).__doc__
+                      for name in dir(self)
+                      if name.startswith('do_'))
+
+    def usage(self, msg):
+        if msg:
+            print msg
+        basename = os.path.basename(self.args[0])
+        print 'Usage: %s [%s]' % (basename, '|'.join(self.commands()))
+        sys.exit(2)
 
 if __name__ == '__main__':
-    main()
+    Client(sys.argv).run()

--- a/rtp/common/config.py
+++ b/rtp/common/config.py
@@ -6,6 +6,10 @@ host = "localhost"
 game_port = 8888
 web_port = 8880
 
+# Server
+
+game_rate = 1.0
+
 # Client
 
 frame_rate = 30

--- a/rtp/server/game.py
+++ b/rtp/server/game.py
@@ -18,7 +18,21 @@ class Game(object):
         self.looper = task.LoopingCall(self.loop)
         self.players = {}
         self.free_cars = set(range(config.max_players))
+        self._rate = config.game_rate
         self.started = False
+
+    @property
+    def rate(self):
+        return self._rate
+
+    @rate.setter
+    def rate(self, value):
+        if value != self._rate:
+            print 'change game rate to %d frames per second' % value
+            self._rate = value
+            if self.started:
+                self.looper.stop()
+                self.looper.start(1.0 / self._rate)
 
     def start(self):
         if self.started:
@@ -26,7 +40,7 @@ class Game(object):
         self.track = track.Track()
         for player in self.players.values():
             player.reset()
-        self.looper.start(1)
+        self.looper.start(1.0 / self._rate)
         self.started = True
 
     def stop(self):

--- a/rtp/server/main.py
+++ b/rtp/server/main.py
@@ -97,6 +97,9 @@ class XMLRPC(xmlrpc.XMLRPC):
         except error.GameNotStarted as e:
             raise xmlrpc.Fault(1, str(e))
 
+    def xmlrpc_set_rate(self, rate):
+        self.game.rate = rate
+
 def main():
     g = game.Game()
     reactor.listenTCP(config.game_port, Server(g))


### PR DESCRIPTION
Game rate was hardcoded in the server. Now it is configurable and
changeable while a game is running using the xmlrpc interface. Slowing
down the game is useful when you try to debug your driver, and making it
faster is useful for compraing drivers quickly.

To add the new verb, the rtp-admin tool was rewritten in a more
extensible way, so it will be eaiser to add more commands.
