### PR TITLE
rtp-admin: Add server address argument

### DIFF
--- a/README
+++ b/README
@@ -23,16 +23,16 @@ For drive modules, see the examples direcotory.
 
 To start a race, use rtp-admin tool on any machine:
 
-    ./rtp-admin start
+    ./rtp-admin <server-address> start
 
 To stop a race, use rtp-admin tool on any machine:
 
-    ./rtp-admin stop
+    ./rtp-admin <server-address> stop
 
 To modify the game rate, you can use set-rate command. The following command
 would change game rate to 10 frames per second:
 
-    ./rtp-admin set-rate 10
+    ./rtp-admin <server-address> set-rate 10
 
 Creating a tarball
 ------------------

--- a/rtp-admin
+++ b/rtp-admin
@@ -5,20 +5,24 @@ import os
 import xmlrpclib
 from rtp.common import config
 
-server_address = 'localhost'
-
 class Client(object):
 
     def __init__(self, args):
         self.args = args
+        self.server = None
+
+    def run(self):
+        if len(self.args) < 2:
+            self.usage('server-address required')
+
+        server_address = self.args[1]
         url = 'http://%s:%d/rpc2' % (server_address, config.web_port)
         self.server = xmlrpclib.Server(url)
 
-    def run(self):
-        if len(sys.argv) < 2:
-            self.usage('No verb specified')
+        if len(self.args) < 3:
+            self.usage('Verb required')
 
-        verb = self.args[1]
+        verb = self.args[2]
         method_name = 'do_' + verb.replace('-', '_')
         try:
             method = getattr(self, method_name)
@@ -40,9 +44,9 @@ class Client(object):
 
     def do_set_rate(self):
         """set-rate RATE"""
-        if len(self.args) < 3:
+        if len(self.args) < 4:
             self.usage("RATE required")
-        rate = float(self.args[2])
+        rate = float(self.args[3])
         self.server.set_rate(rate)
 
     def commands(self):
@@ -50,11 +54,12 @@ class Client(object):
                       for name in dir(self)
                       if name.startswith('do_'))
 
-    def usage(self, msg):
+    def usage(self, msg=None):
         if msg:
             print msg
         basename = os.path.basename(self.args[0])
-        print 'Usage: %s [%s]' % (basename, '|'.join(self.commands()))
+        commands = '|'.join(self.commands())
+        print 'Usage: %s <server-address> [%s]' % (basename, commands)
         sys.exit(2)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously the server address was hard-coded in rtp-admin. To control
remote server, rtp-admin tool had to be modified. Now the server address
is specified in the command line:

```
rtp-admin server-address verb [verb-options]
```
