### PR TITLE
client: Exit after server error

### DIFF
--- a/rtp/client/game.py
+++ b/rtp/client/game.py
@@ -97,6 +97,7 @@ class Game(component.Component):
 
     def client_error(self, error):
         print 'client error:', error.get('message')
+        reactor.stop()
 
     def client_update(self, info):
         print 'client_update', info


### PR DESCRIPTION
If server return an error response, exit the client instead of trying to
reconnecting. Usually these errors means client sent a bad request.
