### PR TITLE
solution for #113 issue, life calculation

### DIFF
--- a/rose/common/config.py
+++ b/rose/common/config.py
@@ -63,5 +63,6 @@ cells_per_player = matrix_width / max_players
 
 score_move_forward = 10
 score_move_backward = -10
+score_move_forward_punish = score_move_forward / 2
 score_jump = 5
 score_brake = 4

--- a/rose/server/score.py
+++ b/rose/server/score.py
@@ -34,6 +34,8 @@ def process(players, track):
             if player.action != actions.JUMP:
                 track.clear(player.x, player.y)
                 player.y += 1
+                if not player.in_lane():
+                    player.y += 1
                 player.score += config.score_move_backward
             else:
                 player.score += config.score_jump
@@ -48,6 +50,8 @@ def process(players, track):
             if player.action != actions.BRAKE:
                 track.clear(player.x, player.y)
                 player.y += 1
+                if not player.in_lane():
+                    player.y += 1
                 player.score += config.score_move_backward
             else:
                 player.score += config.score_brake
@@ -55,7 +59,10 @@ def process(players, track):
             if player.action == actions.PICKUP:
                 track.clear(player.x, player.y)
                 player.y -= 1
-                player.score += config.score_move_forward
+                if not player.in_lane():
+                    player.score += config.score_move_forward_punish
+                else:
+                    player.score += config.score_move_forward
 
         # Here we can end the game when player gets out of
         # the track bounds. For now, just keep the player at the same


### PR DESCRIPTION
issue - Life calculations should be change when driving not in your lane #113 solved
random driver hasn't changed
In the rose/common/config.py I added a veriable which supposed to lower the score by 20 when the player or when the car is not in his lane.
At the server/player.py code, I added a function which calculate the boundaries of the lane and returns a True value when the player not in his lane.
At the score code I used the move_extra_backwards, so it will punish the player by extra 10.
