### PR TITLE
Print error message in server when adding an existing player

### DIFF
--- a/rose/server/main.py
+++ b/rose/server/main.py
@@ -22,6 +22,7 @@ class Player(basic.LineReceiver):
             msg = message.parse(line)
             self.dispatch(msg)
         except error.Error as e:
+            print "Error handling message: %s" % e
             msg = message.Message('error', {'message': str(e)})
             self.sendLine(str(msg))
             self.transport.loseConnection()


### PR DESCRIPTION
Solves #148 
Here an example of the output :
add player: Random Driver lane: 0 car: 3
Error handling message: Player exists: Random Driver
