### PR TITLE
Provide server address as a parameter from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Start up two clients:
 
     ./rose-client mydriver.py
 
+The server FQDN/IP address can be specified that way:
+
+    ./rose-client --server-address example.com mydriver.py
+
 For driver modules, see the examples directory.
 
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Start up two clients:
 
     ./rose-client mydriver.py
 
-The server FQDN/IP address can be specified that way:
+The server address can be specified that way (Replace '10.20.30.44' with your server address):
 
-    ./rose-client --server-address example.com mydriver.py
+    ./rose-client -s 10.20.30.44 mydriver.py
 
 For driver modules, see the examples directory.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,6 +27,10 @@ Start up to 2 clients:
 
     ./rose-client mydriver.py
 
+The server FQDN/IP address can be specified that way:
+
+    ./rose-client --server-address example.com mydriver.py
+
 For driver modules, see the examples directory.
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,9 +27,9 @@ Start up to 2 clients:
 
     ./rose-client mydriver.py
 
-The server FQDN/IP address can be specified that way:
+The server address can be specified that way (Replace '10.20.30.44' with your server address):
 
-    ./rose-client --server-address example.com mydriver.py
+    ./rose-client -s 10.20.30.44 mydriver.py
 
 For driver modules, see the examples directory.
 

--- a/docs/examples/driver.md
+++ b/docs/examples/driver.md
@@ -14,11 +14,6 @@ package:
 The obstacles modules is needed for detecting obstacles on the racing track.
 The actions module is needed for the drive function.
 
-Define the server_address variable - this is the IP address (10.1.2.3) or a
-fully qualified domain name (dhcp-10-231) of the game server.
-
-    server_address = "10.1.2.3"
-
 Define the driver_name variable - this string is rendered below your car on
 everyone's screen.
 

--- a/examples/README
+++ b/examples/README
@@ -9,11 +9,6 @@ package:
 The obstacles modules is needed for detecting obstacles on the racing track.
 The actions module is needed for the drive function.
 
-Define the server_address variable - this is the IP address (10.1.2.3) or a
-fully qualified domain name (dhcp-10-231) of the game server.
-
-    server_address = "10.1.2.3"
-
 Define the driver_name variable - this string is rendered below your car on
 everyone's screen.
 

--- a/examples/none.py
+++ b/examples/none.py
@@ -3,7 +3,6 @@ This driver does not do any action.
 """
 from rose.common import obstacles, actions  # NOQA
 
-server_address = "localhost"
 driver_name = "No Driver"
 
 

--- a/examples/random-driver.py
+++ b/examples/random-driver.py
@@ -7,7 +7,6 @@ very good driver but the implementation is very elegant.
 import random
 from rose.common import obstacles, actions  # NOQA
 
-server_address = "localhost"
 driver_name = "Random Driver"
 
 

--- a/rose/client/main.py
+++ b/rose/client/main.py
@@ -97,10 +97,14 @@ def load_driver_module(file_path):
 def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="ROSE Client")
-    parser.add_argument("driver_file", help="The path to the driver file")
-    parser.add_argument("--server-address", dest="server_address",
-                        help="The server FQDN/IP address to connect to."
-                        " If not specified, localhost will be used.")
+    parser.add_argument("--server-address", "-s", dest="server_address",
+                        default="localhost",
+                        help="The server address to connect to."
+                             " For example: '10.20.30.44' or 'my-server.com'."
+                             " If not specified, localhost will be used.")
+    parser.add_argument("driver_file",
+                        help="The path to the driver python module")
+
     args = parser.parse_args()
 
     try:
@@ -109,14 +113,10 @@ def main():
         log.error("error loading driver module %r: %s", args.driver_file, e)
         sys.exit(2)
 
-    server_address = "127.0.0.1"
-    if args.server_address:
-        server_address = args.server_address
-
-    reactor.connectTCP(server_address, config.game_port,
+    reactor.connectTCP(args.server_address, config.game_port,
                        ClientFactory(driver_mod.driver_name, driver_mod.drive))
 
-    url = "http://%s:%d" % (server_address, config.web_port)
-    log.info("Game URL: %s" % url)
+    url = "http://%s:%d" % (args.server_address, config.web_port)
+    log.info("Please open %s to watch the game." % url)
 
     reactor.run()

--- a/rose/client/main.py
+++ b/rose/client/main.py
@@ -1,3 +1,4 @@
+import argparse
 import imp
 import logging
 import os.path
@@ -95,15 +96,27 @@ def load_driver_module(file_path):
 
 def main():
     logging.basicConfig(level=logging.INFO)
-    if len(sys.argv) < 2:
-        log.info('usage: rose-client drive-module')
-        sys.exit(2)
+    parser = argparse.ArgumentParser(description="ROSE Client")
+    parser.add_argument("driver_file", help="The path to the driver file")
+    parser.add_argument("--server-address", dest="server_address",
+                        help="The server FQDN/IP address to connect to."
+                        " If not specified, localhost will be used.")
+    args = parser.parse_args()
+
     try:
-        driver_mod = load_driver_module(sys.argv[1])
+        driver_mod = load_driver_module(args.driver_file)
     except ImportError as e:
-        log.error("error loading driver module %r: %s", sys.argv[1], e)
+        log.error("error loading driver module %r: %s", args.driver_file, e)
         sys.exit(2)
 
-    reactor.connectTCP(driver_mod.server_address, config.game_port,
+    server_address = "127.0.0.1"
+    if args.server_address:
+        server_address = args.server_address
+
+    reactor.connectTCP(server_address, config.game_port,
                        ClientFactory(driver_mod.driver_name, driver_mod.drive))
+
+    url = "http://%s:%d" % (server_address, config.web_port)
+    log.info("Game URL: %s" % url)
+
     reactor.run()


### PR DESCRIPTION
This PR adds support for providing server address as an optional parameter from command line.

The server address in the 'Driver' code is not needed. If present it will be ignored.

When running the rose-client , the 'server-address' parameter provided will be used as FQDN/IP address of the server that the client will connect to.
If it is not provided localhost (127.0.0.1) will be used.

In addition, the URL of the game is printed in the console.

This support also enable the use of compiled drivers with any server.

Here is the help output of the command:
```
./rose-client -h
usage: rose-client [-h] [--server-address SERVER_ADDRESS] driver_file

ROSE Client

positional arguments:
  driver_file           The path to the driver python module

optional arguments:
  -h, --help            show this help message and exit
  --server-address SERVER_ADDRESS, -s SERVER_ADDRESS
                        The server address to connect to. For example:
                        '10.20.30.44' or 'my-server.com'. If not specified,
                        localhost will be used.

```

Fixes #221 