### PR TITLE
Omit test modules in coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *_test.py


### PR DESCRIPTION
Add .coveragerc file omitting the tests modules. Now coverage show the
true value - 20%.

---------- coverage: platform linux2, python 2.7.13-final-0 ----------
Name                       Stmts   Miss  Cover
----------------------------------------------
rose/__init__.py               0      0   100%
rose/client/__init__.py        1      1     0%
rose/client/car.py            32     32     0%
rose/client/component.py       4      4     0%
rose/client/dashboard.py      36     36     0%
rose/client/end.py            11     11     0%
rose/client/finish.py         17     17     0%
rose/client/game.py           87     87     0%
rose/client/main.py           51     51     0%
rose/client/splash.py         11     11     0%
rose/client/track.py          42     42     0%
rose/client/world.py          13     13     0%
rose/common/__init__.py        0      0   100%
rose/common/actions.py         7      0   100%
rose/common/config.py         38      0   100%
rose/common/error.py          25     25     0%
rose/common/message.py        17     17     0%
rose/common/obstacles.py      11      1    91%
rose/server/__init__.py        0      0   100%
rose/server/game.py           93     93     0%
rose/server/main.py          110    110     0%
rose/server/player.py         27      2    93%
rose/server/score.py          48      0   100%
rose/server/track.py          28     11    61%
----------------------------------------------
TOTAL                        709    564    20%

Fixes #166.