### PR TITLE
Remove last traces of pygame

### DIFF
--- a/rose/client/car.py
+++ b/rose/client/car.py
@@ -1,6 +1,3 @@
-import random
-import os
-from rose.common import config
 import component
 
 class Car(component.Component):
@@ -9,7 +6,6 @@ class Car(component.Component):
         self.id = id
         self.x = None
         self.y = None
-        self.texture = None
         self.name = None
 
     def update(self, info):

--- a/rose/client/game.py
+++ b/rose/client/game.py
@@ -1,7 +1,7 @@
 import time
 from twisted.internet import reactor
 
-from rose.common import config, message
+from rose.common import message
 import track
 import car
 import world

--- a/rose/client/track.py
+++ b/rose/client/track.py
@@ -1,5 +1,3 @@
-import glob
-import os
 from rose.common import config, obstacles
 import component
 


### PR DESCRIPTION
Some imports and instance variables are not needed now in the client
package, after pygame was removed in #219.