### PR TITLE
make random-driver names more random

### DIFF
--- a/examples/random-driver.py
+++ b/examples/random-driver.py
@@ -7,8 +7,23 @@ very good driver but the implementation is very elegant.
 import random
 from rose.common import obstacles, actions
 
+attribute = [
+    "Furious",
+    "Big",
+    "Rolling"
+]
+
+names = [
+    "Mike",
+    "Sally",
+    "Jackson",
+    "Sam",
+    "Jane",
+    "Bruce"
+]
+
 server_address = "localhost"
-driver_name = "Random Driver"
+driver_name = "{0} {1}".format(random.choice(attribute), random.choice(names))
 
 def drive(world):
     return random.choice(actions.ALL)


### PR DESCRIPTION
While preparing for a different Todo on the project, I came across that random_driver.py is not really random and can't be run twice. So, I changed the approach of naming the drivers differently.

Hope this works for you. The good about this is for people just wanting to quickly run this project and see what it does, it's easy to just use the random driver twice.

What you think? 