### PR TITLE
Avoid Pipfile.lock in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
     - pip install pipenv
-    - pipenv install --dev --system
+    - pipenv install --dev --system --skip-lock
 
 script:
     - flake8


### PR DESCRIPTION
Travis fails now when trying to lock the packages. Avoid the unneeded
locking step and use the Pipfile instead.

Fixes #228.