### PR TITLE
Remove --system option in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
     - pip install pipenv
-    - pipenv install --dev --system --skip-lock
+    - pipenv install --dev --skip-lock
 
 script:
     - flake8


### PR DESCRIPTION
In travis we are already running inside a virtual environment, so there
is no need for system pip management.

Here is an example run with this patch:

$ pipenv install --dev --skip-lock
Courtesy Notice: Pipenv found itself running within a virtual
environment, so it will automatically use that environment, instead of
creating its own for any project.
Installing dependencies from Pipfile…
🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 6/6 — 00:00:11