### PR TITLE
Remove useless parameters from Car.__init__

### DIFF
--- a/rose/client/car.py
+++ b/rose/client/car.py
@@ -2,7 +2,7 @@ import component
 
 class Car(component.Component):
 
-    def __init__(self, id, x, y):
+    def __init__(self, id):
         self.id = id
         self.x = None
         self.y = None

--- a/rose/client/game.py
+++ b/rose/client/game.py
@@ -18,10 +18,10 @@ class Game(component.Component):
         self.name = name
         self.track = track.Track()
         self.players = {}
-        self.cars = [car.Car(1, 0, 4),
-                     car.Car(2, 1, 4),
-                     car.Car(3, 2, 4),
-                     car.Car(4, 3, 4)]
+        self.cars = [car.Car(1),
+                     car.Car(2),
+                     car.Car(3),
+                     car.Car(4)]
         self.world = world.generate_world(self)
 
     # Component interface


### PR DESCRIPTION
The parameters x and y were not used in the constructor of the Car
class. Removing them has no negative side effect and makes the code
easier to understand.