### PR TITLE
Stop game if no players connected

### DIFF
--- a/rose/server/game.py
+++ b/rose/server/game.py
@@ -46,6 +46,8 @@ class Game(object):
     def start(self):
         if self.started:
             raise error.GameAlreadyStarted()
+        if not self.players:
+            raise error.ActionForbidden("start a game with no players.")
         self.track.reset()
         for p in self.players.values():
             p.reset()
@@ -82,7 +84,11 @@ class Game(object):
         self.free_lanes.add(player.lane)
         log.info('remove player: %r, lane: %r, car: %r',
                  name, player.lane, player.car)
-        reactor.callLater(0, self.update_clients)
+        if not self.players and self.started:
+            log.info('Stopping game. No players connected.')
+            self.stop()
+        else:
+            reactor.callLater(0, self.update_clients)
 
     def drive_player(self, name, info):
         log.info('drive_player: %r %r', name, info)

--- a/rose/web/game.js
+++ b/rose/web/game.js
@@ -44,7 +44,7 @@ var ROSE = (function() {
         var state = msg.payload;
 
         // Update
-        this.controller.update(state.started);
+        this.controller.update(state);
         this.rate.update(state.rate);
         this.dashboard.update(state);
         this.track.update(state);
@@ -135,11 +135,18 @@ var ROSE = (function() {
             })
     }
 
-    Controller.prototype.update = function(running) {
-        if (running) {
+    Controller.prototype.update = function(state) {
+        if(state.players.length == 0){
+            $("#info").text("No players connected")
+            $("#start").attr("disabled", "disabled");
+            $("#stop").attr("disabled", "disabled");
+        }
+        else if (state.started) {
+            $("#info").text("")
             $("#start").attr("disabled", "disabled");
             $("#stop").removeAttr("disabled");
         } else {
+            $("#info").text("")
             $("#start").removeAttr("disabled");
             $("#stop").attr("disabled", "disabled");
         }

--- a/rose/web/index.html
+++ b/rose/web/index.html
@@ -13,6 +13,7 @@
 
         <button id="start" disabled>Start</button>
         <button id="stop"  disabled>Stop</button>
+        <label id="info"></label>
 
         <div id="rate_ctl">
           <label>Speed</label>


### PR DESCRIPTION
Fixes issue #263 

-  frontend: Enable the "Start" button only when at least one player is connected
- frontend: Render "No player connected" message if no player is connected.
- backend: fail start() if no player is connected
- backend: When a player disconnects, stop the game if it was the last player
