### PR TITLE
Correct links on index.md and create materials.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: ROSE Project
-tagline: 
+tagline:
 description: This project is a game that has been developed in order to help teach kids Python
 ---
 
@@ -23,13 +23,14 @@ The race car has to recognize the race track, the obstacles, and the bonus areas
 calculate the best path to take to avoid the pitfalls; and collect bonus points.
 The cars move autonomously on the screen within the race track game with no interference
 from the students. No joystick or mouse would be used.
- 
+
 In order to control the car movements, the students need to implement a 'driver'.
 This code is controlling the car and will decide what will be the next action of the car.
 
 For each type of obstacles there is a different action, and different points.
 
-See [examples/driver](examples/driver) for explanation on how to write a driver module.
+See [materials](materials.md) for our course materials.
 
-See [development](development) for details on getting started
+See [examples/driver](examples/driver.md) for explanation on how to write a driver module.
 
+See [development](development.md) for details on getting started

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -1,0 +1,41 @@
+---
+title: ROSE Project
+tagline: Materials
+description: This project is a game that has been developed in order to help teach kids Python
+---
+
+# Course Materials
+
+Here you may find ROSE course materials, presentations and home work exercises sectioned by subjects:
+
+<html>
+<style>
+.vertical-menu {
+    width: 260px;
+}
+
+.vertical-menu a {
+    color: #34689C;
+    display: block;
+    padding: 12px;
+    text-decoration: none;
+}
+
+.vertical-menu a:hover {
+    background-color: #ccc;
+}
+
+</style>
+<body>
+<div class="vertical-menu">
+    <a href="meet_linux.html">1. Meet Linux</a>
+    <a href="#">2. Variables and Data Types</a>
+    <a href="#">3. Control Structures</a>
+    <a href="#">4. Compound Data Types</a>
+    <a href="#">5. Object Orientation</a>
+    <a href="#">6. Exceptions</a>
+    <a href="#">7. Functions and Functional Programming</a>
+</div>
+
+</body>
+</html>

--- a/docs/meet_linux.md
+++ b/docs/meet_linux.md
@@ -1,0 +1,67 @@
+---
+title: ROSE Project
+tagline: Materials
+description: This project is a game that has been developed in order to help teach kids Python
+---
+<html>
+<style>
+.vertical-menu {
+    float: left;
+    width: 260px;
+}
+
+.vertical-menu a {
+    color: #34689C;
+    display: block;
+    padding: 12px;
+    text-decoration: none;
+}
+
+.vertical-menu a:hover {
+    background-color: #ccc;
+}
+
+.holder {
+	margin-left: 260px;
+	padding-left: 20px;
+}
+</style>
+<body>
+
+<div class="vertical-menu">
+    <a href="meet_linux.html">1. Meet Linux</a>
+    <a href="#">2. Variables and Data Types</a>
+    <a href="#">3. Control Structures</a>
+    <a href="#">4. Compound Data Types</a>
+    <a href="#">5. Object Orientation</a>
+    <a href="#">6. Exceptions</a>
+    <a href="#">7. Functions and Functional Programming</a>
+</div>
+
+<div class="holder">
+    <h2 style="color:#159957;">Meet Linux</h2>
+    this is the meet_linux page!<br>
+    bla bla <br>
+    bla<br>
+    a<br>
+    b<br>
+    c<br>
+    a<br>
+    b<br>
+    c<br>
+    a<br>
+    b<br>
+    c<br>
+    a<br>
+    b<br>
+    c<br>
+    a<br>
+    b<br>
+    c<br>
+    a<br>
+    b<br>
+    c<br>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This patch corrects the links appear on index.md, and also
creates materials.md, which will contain the course materials.
Each course topic will have its own page, which (supposed to) include the
presentation shown on class, home works, exercises and extras.