### PR TITLE
ROSE Server in a Docker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docs/
+examples/
+Makefile
+README*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use official CentOS Python 2.7 image
+# https://developer.fedoraproject.org/tools/docker/docker-images.html
+FROM centos/python-27-centos7 AS base
+
+# Project maintainer
+LABEL maintainer="frolland@redhat.com"
+
+# Required env vars
+ENV LD_LIBRARY_PATH="/opt/rh/python27/root/usr/lib64/" \
+    ENABLE_PIPENV=true
+
+# Install pipenv
+RUN pip install --upgrade pipenv
+
+# Copy application to default WORKDIR
+COPY . ./
+
+# Install dependencies from pipfile
+RUN pipenv install
+
+# Server port
+EXPOSE 8880
+
+# Server command
+ENTRYPOINT [ "pipenv" ]
+CMD [ "run", "python", "rose-server"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Start the server on some machine:
 
 Open a browser at http://\<server-address\>:8880 to view and control the game.
 
+### Running the server in Docker
+
+Build the Docker image:
+
+    docker build -t rose:server .
+
+Run the Docker image on port 8880:
+
+    docker run -it --rm -p 8880 rose:server
+
+Open a browser at http://\<server-address\>:8880 to view and control the game.
+
 ## Running a driver
 
 Open a pipenv shell that you'll use for the following commands:


### PR DESCRIPTION
Fixes #173

Uses official CentOS Python 2.7 image.

Verified building and running locally and can access ROSE Server on http://locahlost:8880