### PR TITLE
Added an option for running the game with the same track for all drivers

### DIFF
--- a/rose/common/config.py
+++ b/rose/common/config.py
@@ -10,6 +10,7 @@ web_port = 8880
 game_rate = 1.0
 game_duration = 60
 number_of_cars = 4
+is_track_random = True
 
 # Matrix
 

--- a/rose/server/main.py
+++ b/rose/server/main.py
@@ -1,5 +1,6 @@
 import socket
 import logging
+import argparse
 
 from twisted.internet import reactor
 from twisted.web import server, static
@@ -14,6 +15,22 @@ log = logging.getLogger('main')
 
 def main():
     logging.basicConfig(level=logging.INFO, format=config.logger_format)
+    parser = argparse.ArgumentParser(description="ROSE Server")
+    parser.add_argument("--track_definition", "-t", dest="track_definition",
+                        default="random", choices=["random", "same"],
+                        help="Definition of driver tracks: random or same."
+                             "If not specified, random will be used.")
+
+    args = parser.parse_args()
+    """
+    If the argument is 'same', the track will generate the obstacles in the same place for both drivers.
+    Otherwise, the obstacles will be genrated in random locations for each driver.
+    """
+    if args.track_definition=="same":
+        config.is_track_random = False
+    else:
+        config.is_track_random = True
+    
     log.info('starting server')
     g = game.Game()
     h = net.Hub(g)

--- a/rose/server/track.py
+++ b/rose/server/track.py
@@ -49,13 +49,19 @@ class Track(object):
         Generates new row with obstacles
 
         Try to create fair but random obstacle stream. Each player get the same
-        obstacles, but in different cells.
+        obstacles, but in different cells if 'is_track_random' is True.
+        Otherwise, the tracks will be identical.
         """
         row = [obstacles.NONE] * config.matrix_width
         obstacle = obstacles.get_random_obstacle()
-        for lane in range(config.max_players):
-            low = lane * config.cells_per_player
-            high = low + config.cells_per_player
-            cell = random.choice(range(low, high))
-            row[cell] = obstacle
+        if config.is_track_random:
+            for lane in range(config.max_players):
+                low = lane * config.cells_per_player
+                high = low + config.cells_per_player
+                cell = random.choice(range(low, high))
+                row[cell] = obstacle
+        else:
+            cell = random.choice(range(0, config.cells_per_player))
+            for lane in range(config.max_players):
+                row[cell + lane * config.cells_per_player] = obstacle
         return row


### PR DESCRIPTION
Trigger the option by running ./rose-server -t same.
If ./rose-server is used the obstacles will be randomly placed.

Checked the game functionality, everything works properly.
Didn't update the README yet. Do you want to show the option on the main README?