### PR TITLE
Add UTF-8 encoding to HTML

### DIFF
--- a/rose/web/index.html
+++ b/rose/web/index.html
@@ -1,7 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 
   <head>
+    <meta charset="UTF-8">
     <title>ROSE Game</title>
     <link rel="stylesheet" type="text/css" href="game.css">
   </head>


### PR DESCRIPTION
Previously encoding was unset, which resulted in an error in the console and potentially wrong encoding with various browsers.