### PR TITLE
Remove CI tests for python2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.7"
 
 install:


### PR DESCRIPTION
Since `python2.7` is no longer supported and AFAIK we have nothing in ROSE project
that needs to run with 2.7