### PR TITLE
score.py: avoid failing on flake8 test

### DIFF
--- a/rose/server/score.py
+++ b/rose/server/score.py
@@ -46,7 +46,7 @@ def process(players, track):
         elif obstacle in (obstacles.TRASH,
                           obstacles.BIKE,
                           obstacles.BARRIER):
-            if player.action != actions.LEFT and player.action != actions.RIGHT:
+            if player.action not in (actions.LEFT, actions.RIGHT):
                 track.clear(player.x, player.y)
                 player.y += 1
                 player.score += config.score_move_backward * 2


### PR DESCRIPTION
The line's length is currently 80>79 chars.
This patch tries to fix it, so the Travis test won't fail.