### PR TITLE
moved from pipenv to venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ open a new session.
 Use venv to create a virtual environment and to install the rest of
 the dependencies:
 
-    python -m venv ~/.venv/rose
+    python3 -m venv ~/.venv/rose
 
 After creating the environment, we want to activate and enter our
 environment (make sure you're in the ROSE directory):

--- a/README.md
+++ b/README.md
@@ -52,48 +52,36 @@ Refer to our GitHub pages for the course materials and additional resources:
 - [Read](https://opensource.com/education/15/9/open-source-education-israel)
   an article by Laura Novich on [opensource.com](https://opensource.com)
 
-## Requirements
-
-Once we're in the ROSE directory, we need to verify we have pipenv
-installed.  In order to make sure we have pipenv installed:
-
-    pipenv --version
-
-If you don't have it installed, the best way is to install it only for
-your user:
-
-    python -m pip install --user pipenv
-
 ## Getting started
 
 The following commands should be performed only once; after creating the
 environment you will be connecting to the same environment each time you
 open a new session.
 
-Use pipenv to create a virtual environment and to install the rest of
+Use venv to create a virtual environment and to install the rest of
 the dependencies:
 
-    pipenv install
-
-You can also install development packages by running:
-
-    pipenv --dev install
+    python -m venv ./venv
 
 After creating the environment, we want to activate and enter our
 environment (make sure you're in the ROSE directory):
 
-    pipenv shell
+    source ./venv/bin/activate
+
+After entering the virtual enviornment we need to install the project dependencies:
+
+    pip install -r requirments.txt
 
 Indication that you are inside the environment, the prompt line will
 look like this:
 
-    (ROSE) [username@hostname ROSE]$
+    (venv) [username@hostname ROSE]$
 
 ## Running the server
 
 If you are not in your virtual environment, please run it:
 
-    pipenv shell
+    source ./venv/bin/activate
 
 Start the server on some machine:
 
@@ -147,7 +135,7 @@ blocked by [firewalld](https://firewalld.org/):
 
 In a new window, open your virtual environment:
 
-    pipenv shell
+    source ./venv/bin/activate
 
 Create your driver file:
 
@@ -197,7 +185,7 @@ following command would change game rate to 10 frames per second:
 
 `./rose-server` and `./rose-client {driver name}` do not return, but
 continue running, in order to run both server and drivers a user need to
-run them in separate shells, Each driver will run it it's own pipenv
+run them in separate shells, Each driver will run it it's own venv
 shell. `tmux` may be useful in this case.
 
 Example `tmux` commands:

--- a/README.md
+++ b/README.md
@@ -61,27 +61,27 @@ open a new session.
 Use venv to create a virtual environment and to install the rest of
 the dependencies:
 
-    python -m venv ./venv
+    python -m venv ~/.venv/rose
 
 After creating the environment, we want to activate and enter our
 environment (make sure you're in the ROSE directory):
 
-    source ./venv/bin/activate
+    source ~/.venv/rose/bin/activate
 
 After entering the virtual enviornment we need to install the project dependencies:
 
-    pip install -r requirments.txt
+    pip install -r requirements.txt
 
 Indication that you are inside the environment, the prompt line will
 look like this:
 
-    (venv) [username@hostname ROSE]$
+    (rose) [username@hostname ROSE]$
 
 ## Running the server
 
-If you are not in your virtual environment, please run it:
+If you are not in your virtual environment, please activate it:
 
-    source ./venv/bin/activate
+    source ~/.venv/rose/bin/activate
 
 Start the server on some machine:
 
@@ -185,7 +185,7 @@ following command would change game rate to 10 frames per second:
 
 `./rose-server` and `./rose-client {driver name}` do not return, but
 continue running, in order to run both server and drivers a user need to
-run them in separate shells, Each driver will run it it's own venv
+run them in separate shells, using the same virtual environment.
 shell. `tmux` may be useful in this case.
 
 Example `tmux` commands:
@@ -205,13 +205,17 @@ Example `tmux` commands:
 Should you want to contribute to the project, please read the
 [Code of Conduct](docs/code-of-conduct.md).
 
+To create venv use:
+
+    python3 -m venv ~/.venv/rose
+    
+To enter the venv:
+
+    source ~/.venv/rose/bin/activate
+
 To install development requirements:
 
-    pipenv install --dev
-
-To open a shell for development, use:
-
-    pipenv shell
+    pip install -r requirements-dev.txt
 
 For development in docker, use:
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ blocked by [firewalld](https://firewalld.org/):
 
 In a new window, open your virtual environment:
 
-    source ./venv/bin/activate
+    source ~/.venv/rose/bin/activate
 
 Create your driver file:
 


### PR DESCRIPTION
Due to an issue encountered with fedora nodes we decided to move to venv instead of pipenv having that it is shipped with python and does not require any addtional installations