### PR TITLE
Using UBI work image for smaller container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Generate a container that generates requirements.txt
-ARG PY_VERSION=3.7
+ARG PY_VERSION=3.9
 FROM python:${PY_VERSION} as source
 
 ARG DEV
@@ -14,14 +14,13 @@ COPY Pipfile ./Pipfile
 # Generate requirements.txt file from Pipfile
 RUN if [ -z ${DEV} ]; \
     then \
-        pipenv lock -r > requirements.txt; \
+        pipenv lock > requirements.txt; \
     else \
-        pipenv lock --dev -r > requirements.txt; \
+        pipenv lock --dev > requirements.txt; \
     fi
 
 # Generate work image
-ARG PY_VERSION
-FROM python:${PY_VERSION}
+FROM registry.access.redhat.com/ubi9/python-39
 
 # Project maintainer
 LABEL maintainer="frolland@redhat.com"

--- a/Pipfile
+++ b/Pipfile
@@ -26,4 +26,4 @@ idna = ">=2.5,<3"
 
 [requires]
 
-python_version = "3.7"
+python_version = "3.9"


### PR DESCRIPTION
If possible to upgrade to Python 3.9, we could use the UBI9 Python image to reduce size. Fixes #451