### PR TITLE
changed the Play button to Music button

### DIFF
--- a/rose/web/game.js
+++ b/rose/web/game.js
@@ -427,7 +427,7 @@ var ROSE = (function() {
             if (self.playing) {
                 self.playing = false;
                 self.pause();
-                $(this).text("Play");
+                $(this).text("Music");
             } else {
                 self.playing = true;
                 self.play();

--- a/rose/web/index.html
+++ b/rose/web/index.html
@@ -14,7 +14,7 @@
 
         <button id="start" disabled>Start</button>
         <button id="stop"  disabled>Stop</button>
-        <button id="music_ctl">Play</button>
+        <button id="music_ctl">Music</button>
         <label id="info"></label>
 
         <div id="rate_ctl">


### PR DESCRIPTION
Submitted by Itay Hofshy, Avia Izakovitch, Gavriel Fernanadez.

why?
While working on our driver's code, we got confused many times by the "Play" button, since it seemed that this button starts the game, but it actually starts the music. We changed its name to "Music" so that the player will not get confused anymore.

Screenshots:
![1](https://github.com/RedHat-Israel/ROSE/assets/125301696/c9a67940-da0b-48ed-951f-374f1b73d90f)
![2](https://github.com/RedHat-Israel/ROSE/assets/125301696/1a7a6355-8abb-4e4d-bfa1-bbc7895d8c0f)
