### PR TITLE
Explictly test for players car in lane

### DIFF
--- a/rose/server/player.py
+++ b/rose/server/player.py
@@ -27,9 +27,8 @@ class Player(object):
         self.score = 0
 
     def in_lane(self):
-        min_x = self.lane * config.cells_per_player
-        next_x = min_x + config.cells_per_player
-        return min_x <= self.x < next_x
+        current_lane = self.x // config.cells_per_player
+        return current_lane == self.lane
 
     def __cmp__(self, other):
         x = self.score

--- a/rose/server/player.py
+++ b/rose/server/player.py
@@ -4,6 +4,25 @@ from rose.common import actions, config
 class Player(object):
 
     def __init__(self, name, car, lane):
+        """
+        Creates a new Driver object.
+        Args:
+            name (str): The unique name of the driver for display.
+            car (int): A number from 0 to 3, representing the car type.
+            lane (int): The initial lane number, between 0 and the
+                            maximum lane.
+
+        Attributes:
+            x (int, optional): The X-coordinate of the driver.
+                                Starts in the middle of the lane.
+            y (int, optional): The Y-coordinate of the driver.
+                                Starts at 2/3 of the screen height.
+            action (str, optional): The current driver action. Defaults
+                                        to 'none'.
+            response_time (float, optional): The duration the driver takes
+                                                to react. Starts as None.
+            score (int, optional): The driver's current score. Begins at 0.
+        """
         self.name = name
         self.car = car
         self.lane = lane
@@ -23,7 +42,7 @@ class Player(object):
         self.x = self.lane * config.cells_per_player + 1  # | |0| | |1 | |
         self.y = config.matrix_height // 3 * 2             # 1/3 of track
         self.action = actions.NONE
-        self.response_time = 1.0
+        self.response_time = None
         self.score = 0
 
     def in_lane(self):

--- a/rose/server/player_test.py
+++ b/rose/server/player_test.py
@@ -1,15 +1,80 @@
+from rose.common import actions, config
 from . import player
 
 
-def test_in_lane():
-    p = player.Player("A", car=0, lane=0)
-    for x in (0, 1, 2):
-        p.x = x
-        assert p.in_lane()
+def test_player_initialization():
+    player1 = player.Player("John", 1, 1)
+
+    assert player1.name == "John"
+    assert player1.car == 1
+    assert player1.lane == 1
+    # player.Player x value should be middle of it's lane
+    assert player1.x == player1.lane * config.cells_per_player + 1
+    assert player1.y == config.matrix_height // 3 * 2
+    assert player1.action == actions.NONE
+    assert player1.response_time is None
+    assert player1.score == 0
 
 
-def test_not_in_lane():
-    p = player.Player("A", car=0, lane=1)
-    for x in (0, 1, 2):
-        p.x = x
-        assert not p.in_lane()
+def test_player_reset():
+    player1 = player.Player("John", 1, 1)
+
+    player1.score = 50  # Modify player to make sure reset works
+    player1.reset()
+    assert player1.x == player1.lane * config.cells_per_player + 1
+    assert player1.y == config.matrix_height // 3 * 2
+    assert player1.action == actions.NONE
+    assert player1.response_time is None
+    assert player1.score == 0
+
+
+def test_player_in_lane():
+    player1 = player.Player("John", 1, 1)
+
+    lane_start = player1.lane * config.cells_per_player
+
+    for offset in range(config.cells_per_player):
+        player1.x = lane_start + offset
+        assert player1.in_lane()
+
+
+def test_player_not_in_lane():
+    player1 = player.Player("John", 1, 1)
+
+    # Modify player's position to be out of their lane
+    other_lane = (player1.lane + 1) % config.max_players
+    other_lane_start = other_lane * config.cells_per_player
+
+    for offset in range(config.cells_per_player):
+        player1.x = other_lane_start + offset
+        assert not player1.in_lane()
+
+
+def test_player_comparison():
+    player1 = player.Player("John", 1, 1)
+    player2 = player.Player("Doe", 2, 2)
+
+    # Initial scores are the same
+    assert not player1 < player2
+    assert not player2 < player1
+
+    # Modify scores
+    player1.score = 10
+    player2.score = 20
+
+    assert player1 < player2
+
+
+def test_player_state():
+    player1 = player.Player("John", 1, 1)
+
+    expected_state = {
+        'name': player1.name,
+        'car': player1.car,
+        'x': player1.x,
+        'y': player1.y,
+        'lane': player1.lane,
+        'score': player1.score
+    }
+
+    assert player1.state() == expected_state


### PR DESCRIPTION
Issue:
When testing if a car is in lane, we do an implicit test, calculating the start and end x value of the player lane, it's better to use explicit calculation to get the lane directly from car position.